### PR TITLE
Added ability to auto-accept webrtc permissions boxes

### DIFF
--- a/lib/core/eventmanager.cpp
+++ b/lib/core/eventmanager.cpp
@@ -12,10 +12,17 @@ EventManager::EventManager(QObject *parent)
 {
 }
 
+
+void EventManager::featurePermissionRequested(const QUrl & securityOrigin, QWebEnginePage::Feature f) {
+    ElectricWebView::instance()->webView()->page()->setFeaturePermission(ElectricWebView::instance()->webView()->page()->url(), f, QWebEnginePage::PermissionGrantedByUser);
+}
+
 void EventManager::bind()
 {
     QWebEngineView *webView = ElectricWebView::instance()->webView();
 
+    connect(webView->page(), SIGNAL(featurePermissionRequested(const QUrl&, QWebEnginePage::Feature)),
+            SLOT(featurePermissionRequested(const QUrl&, QWebEnginePage::Feature)));
     // url_changed EVENT
     connect(webView, &QWebEngineView::urlChanged, [=](const QUrl &url) {
         foreach (const Event &event, m_subscribers["url_changed"]) {

--- a/lib/core/eventmanager.hpp
+++ b/lib/core/eventmanager.hpp
@@ -4,7 +4,7 @@
 #include <QObject>
 #include <QMap>
 #include <QList>
-
+#include <QWebEnginePage>
 #include "event.hpp"
 
 class QWebEngineView;
@@ -26,6 +26,10 @@ public:
 private:
     QWebEngineView *m_webView;
     QMap<QString, QList<Event> > m_subscribers;
+
+protected slots:
+
+    void featurePermissionRequested(const QUrl & securityOrigin, QWebEnginePage::Feature f);
 };
 
 #endif // EVENTMANAGER_HPP


### PR DESCRIPTION
When attempting to view a page that wants to use the camera / microphone, for example, a webpage with WebRTC, there is currently no way to programmatically "allow" the request from the browser.   This patch auto-allows those features to run by intercepting the event and allowing it.

Thoughts?  I don't know if auto-accepting is a great default for everyone, but it works for my case.  Perhaps expand it to be a configuration flag?  Or fully integrate it as an event?

