### PR TITLE
Changes to allow electric webview to compile on Windows

### DIFF
--- a/lib/command/command.pro
+++ b/lib/command/command.pro
@@ -3,12 +3,6 @@ CONFIG += staticlib
 
 QT += network
 
-INCLUDEPATH += \
-    $$PWD/../
-
-LIBS += \
-    -L$$OUT_PWD/../core -lcore \
-    -L$$OUT_PWD/../transport -ltransport
 
 # Server
 
@@ -27,3 +21,16 @@ SOURCES += \
 HEADERS += \
     $$PWD/commandclient.hpp \
     $$PWD/commandtransportlayer.hpp
+
+win32:CONFIG(release, debug|release): LIBS += -L$$OUT_PWD/../core/release/ -lcore
+else:win32:CONFIG(debug, debug|release): LIBS += -L$$OUT_PWD/../core/debug/ -lcore
+else:unix: LIBS += -L$$OUT_PWD/../core/ -lcore
+
+INCLUDEPATH += $$PWD/../core
+DEPENDPATH += $$PWD/../core
+
+win32-g++:CONFIG(release, debug|release): PRE_TARGETDEPS += $$OUT_PWD/../core/release/libcore.a
+else:win32-g++:CONFIG(debug, debug|release): PRE_TARGETDEPS += $$OUT_PWD/../core/debug/libcore.a
+else:win32:!win32-g++:CONFIG(release, debug|release): PRE_TARGETDEPS += $$OUT_PWD/../core/release/core.lib
+else:win32:!win32-g++:CONFIG(debug, debug|release): PRE_TARGETDEPS += $$OUT_PWD/../core/debug/core.lib
+else:unix: PRE_TARGETDEPS += $$OUT_PWD/../core/libcore.a

--- a/lib/core/core.pro
+++ b/lib/core/core.pro
@@ -3,8 +3,7 @@ CONFIG += staticlib
 
 QT += webenginewidgets
 
-INCLUDEPATH += \
-    $$PWD/../ \
+INCLUDEPATH += $$PWD/../
 
 SOURCES += \
     $$PWD/eventmanager.cpp \

--- a/lib/transport/transport.pro
+++ b/lib/transport/transport.pro
@@ -35,3 +35,16 @@ SOURCES += \
 
 HEADERS += \
     $$PWD/websocket/websocketcommandtransport.hpp
+
+win32:CONFIG(release, debug|release): LIBS += -L$$OUT_PWD/../core/release/ -lcore
+else:win32:CONFIG(debug, debug|release): LIBS += -L$$OUT_PWD/../core/debug/ -lcore
+else:unix: LIBS += -L$$OUT_PWD/../core/ -lcore
+
+INCLUDEPATH += $$PWD/../core
+DEPENDPATH += $$PWD/../core
+
+win32-g++:CONFIG(release, debug|release): PRE_TARGETDEPS += $$OUT_PWD/../core/release/libcore.a
+else:win32-g++:CONFIG(debug, debug|release): PRE_TARGETDEPS += $$OUT_PWD/../core/debug/libcore.a
+else:win32:!win32-g++:CONFIG(release, debug|release): PRE_TARGETDEPS += $$OUT_PWD/../core/release/core.lib
+else:win32:!win32-g++:CONFIG(debug, debug|release): PRE_TARGETDEPS += $$OUT_PWD/../core/debug/core.lib
+else:unix: PRE_TARGETDEPS += $$OUT_PWD/../core/libcore.a

--- a/src/ctl/ctl.pro
+++ b/src/ctl/ctl.pro
@@ -4,17 +4,48 @@ CONFIG += c++11
 
 TARGET = electric-webview-ctl
 
-INCLUDEPATH += \
-    $$PWD/../../lib
-
 SOURCES += \
     main.cpp
-
-LIBS += \
-    -L$$OUT_PWD/../../lib/core -lcore \
-    -L$$OUT_PWD/../../lib/command -lcommand \
-    -L$$OUT_PWD/../../lib/transport -ltransport
 
 target.path = $$PREFIX/bin
 
 INSTALLS += target
+
+win32:CONFIG(release, debug|release): LIBS += -L$$OUT_PWD/../../lib/command/release/ -lcommand
+else:win32:CONFIG(debug, debug|release): LIBS += -L$$OUT_PWD/../../lib/command/debug/ -lcommand
+else:unix: LIBS += -L$$OUT_PWD/../../lib/command/ -lcommand
+
+INCLUDEPATH += $$PWD/../../lib/command
+DEPENDPATH += $$PWD/../../lib/command
+
+win32-g++:CONFIG(release, debug|release): PRE_TARGETDEPS += $$OUT_PWD/../../lib/command/release/libcommand.a
+else:win32-g++:CONFIG(debug, debug|release): PRE_TARGETDEPS += $$OUT_PWD/../../lib/command/debug/libcommand.a
+else:win32:!win32-g++:CONFIG(release, debug|release): PRE_TARGETDEPS += $$OUT_PWD/../../lib/command/release/command.lib
+else:win32:!win32-g++:CONFIG(debug, debug|release): PRE_TARGETDEPS += $$OUT_PWD/../../lib/command/debug/command.lib
+else:unix: PRE_TARGETDEPS += $$OUT_PWD/../../lib/command/libcommand.a
+
+win32:CONFIG(release, debug|release): LIBS += -L$$OUT_PWD/../../lib/core/release/ -lcore
+else:win32:CONFIG(debug, debug|release): LIBS += -L$$OUT_PWD/../../lib/core/debug/ -lcore
+else:unix: LIBS += -L$$OUT_PWD/../../lib/core/ -lcore
+
+INCLUDEPATH += $$PWD/../../lib/core
+DEPENDPATH += $$PWD/../../lib/core
+
+win32-g++:CONFIG(release, debug|release): PRE_TARGETDEPS += $$OUT_PWD/../../lib/core/release/libcore.a
+else:win32-g++:CONFIG(debug, debug|release): PRE_TARGETDEPS += $$OUT_PWD/../../lib/core/debug/libcore.a
+else:win32:!win32-g++:CONFIG(release, debug|release): PRE_TARGETDEPS += $$OUT_PWD/../../lib/core/release/core.lib
+else:win32:!win32-g++:CONFIG(debug, debug|release): PRE_TARGETDEPS += $$OUT_PWD/../../lib/core/debug/core.lib
+else:unix: PRE_TARGETDEPS += $$OUT_PWD/../../lib/core/libcore.a
+
+win32:CONFIG(release, debug|release): LIBS += -L$$OUT_PWD/../../lib/transport/release/ -ltransport
+else:win32:CONFIG(debug, debug|release): LIBS += -L$$OUT_PWD/../../lib/transport/debug/ -ltransport
+else:unix: LIBS += -L$$OUT_PWD/../../lib/transport/ -ltransport
+
+INCLUDEPATH += $$PWD/../../lib/transport
+DEPENDPATH += $$PWD/../../lib/transport
+
+win32-g++:CONFIG(release, debug|release): PRE_TARGETDEPS += $$OUT_PWD/../../lib/transport/release/libtransport.a
+else:win32-g++:CONFIG(debug, debug|release): PRE_TARGETDEPS += $$OUT_PWD/../../lib/transport/debug/libtransport.a
+else:win32:!win32-g++:CONFIG(release, debug|release): PRE_TARGETDEPS += $$OUT_PWD/../../lib/transport/release/transport.lib
+else:win32:!win32-g++:CONFIG(debug, debug|release): PRE_TARGETDEPS += $$OUT_PWD/../../lib/transport/debug/transport.lib
+else:unix: PRE_TARGETDEPS += $$OUT_PWD/../../lib/transport/libtransport.a

--- a/src/ctl/ctl.pro
+++ b/src/ctl/ctl.pro
@@ -4,6 +4,9 @@ CONFIG += c++11
 
 TARGET = electric-webview-ctl
 
+INCLUDEPATH += \
+    $$PWD/../../lib
+
 SOURCES += \
     main.cpp
 

--- a/src/ctl/main.cpp
+++ b/src/ctl/main.cpp
@@ -6,7 +6,11 @@
 #include <QDebug>
 #include <QFile>
 
+#ifdef _WIN64
+#include <io.h>
+#else
 #include <unistd.h>
+#endif
 
 #include <transport/unixsocket/unixsocketcommandtransport.hpp>
 #include <transport/tcp/tcpcommandtransport.hpp>

--- a/src/webview/webview.pro
+++ b/src/webview/webview.pro
@@ -24,3 +24,42 @@ INSTALLS += target
 
 HEADERS += \
     webpage.hpp
+
+win32:CONFIG(release, debug|release): LIBS += -L$$OUT_PWD/../../lib/command/release/ -lcommand
+else:win32:CONFIG(debug, debug|release): LIBS += -L$$OUT_PWD/../../lib/command/debug/ -lcommand
+else:unix: LIBS += -L$$OUT_PWD/../../lib/command/ -lcommand
+
+INCLUDEPATH += $$PWD/../../lib/command
+DEPENDPATH += $$PWD/../../lib/command
+
+win32-g++:CONFIG(release, debug|release): PRE_TARGETDEPS += $$OUT_PWD/../../lib/command/release/libcommand.a
+else:win32-g++:CONFIG(debug, debug|release): PRE_TARGETDEPS += $$OUT_PWD/../../lib/command/debug/libcommand.a
+else:win32:!win32-g++:CONFIG(release, debug|release): PRE_TARGETDEPS += $$OUT_PWD/../../lib/command/release/command.lib
+else:win32:!win32-g++:CONFIG(debug, debug|release): PRE_TARGETDEPS += $$OUT_PWD/../../lib/command/debug/command.lib
+else:unix: PRE_TARGETDEPS += $$OUT_PWD/../../lib/command/libcommand.a
+
+win32:CONFIG(release, debug|release): LIBS += -L$$OUT_PWD/../../lib/core/release/ -lcore
+else:win32:CONFIG(debug, debug|release): LIBS += -L$$OUT_PWD/../../lib/core/debug/ -lcore
+else:unix: LIBS += -L$$OUT_PWD/../../lib/core/ -lcore
+
+INCLUDEPATH += $$PWD/../../lib/core
+DEPENDPATH += $$PWD/../../lib/core
+
+win32-g++:CONFIG(release, debug|release): PRE_TARGETDEPS += $$OUT_PWD/../../lib/core/release/libcore.a
+else:win32-g++:CONFIG(debug, debug|release): PRE_TARGETDEPS += $$OUT_PWD/../../lib/core/debug/libcore.a
+else:win32:!win32-g++:CONFIG(release, debug|release): PRE_TARGETDEPS += $$OUT_PWD/../../lib/core/release/core.lib
+else:win32:!win32-g++:CONFIG(debug, debug|release): PRE_TARGETDEPS += $$OUT_PWD/../../lib/core/debug/core.lib
+else:unix: PRE_TARGETDEPS += $$OUT_PWD/../../lib/core/libcore.a
+
+win32:CONFIG(release, debug|release): LIBS += -L$$OUT_PWD/../../lib/transport/release/ -ltransport
+else:win32:CONFIG(debug, debug|release): LIBS += -L$$OUT_PWD/../../lib/transport/debug/ -ltransport
+else:unix: LIBS += -L$$OUT_PWD/../../lib/transport/ -ltransport
+
+INCLUDEPATH += $$PWD/../../lib/transport
+DEPENDPATH += $$PWD/../../lib/transport
+
+win32-g++:CONFIG(release, debug|release): PRE_TARGETDEPS += $$OUT_PWD/../../lib/transport/release/libtransport.a
+else:win32-g++:CONFIG(debug, debug|release): PRE_TARGETDEPS += $$OUT_PWD/../../lib/transport/debug/libtransport.a
+else:win32:!win32-g++:CONFIG(release, debug|release): PRE_TARGETDEPS += $$OUT_PWD/../../lib/transport/release/transport.lib
+else:win32:!win32-g++:CONFIG(debug, debug|release): PRE_TARGETDEPS += $$OUT_PWD/../../lib/transport/debug/transport.lib
+else:unix: PRE_TARGETDEPS += $$OUT_PWD/../../lib/transport/libtransport.a


### PR DESCRIPTION
I've made changes to the build files which allow you to compile electric-webview on Windows using Visual Studio 2017 in addition to the usual Unix target.  